### PR TITLE
fix: register master as target branch

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -3,7 +3,7 @@ name: Coverage
 
 on:
   push:
-    branches: [main, 'release*']
+    branches: [main, master, 'release*']
 
 jobs:
   update-coverage:


### PR DESCRIPTION
## Changes Summary
register `master` as target branch which needs to run coverage CI