### PR TITLE
feat: serialize data

### DIFF
--- a/bili_jean/models.py
+++ b/bili_jean/models.py
@@ -1,0 +1,106 @@
+"""
+Model of Bilibili data
+"""
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class BaseResponseModel(BaseModel):
+
+    code: int = 0
+    message: str = '0'
+    ttl: Optional[int] = None
+
+
+class GetVideoInfoDataOwner(BaseModel):
+    """
+    Bilibili account who participants in the work
+    """
+    mid: int   # User ID
+    name: str  # User name
+    face: str  # Profile icon's source URL
+
+
+class GetVideoInfoDataPagesItem(BaseModel):
+    """
+    meta info of Bilibili work which is an individual video streaming
+    """
+    cid: int                                    # cid of this page
+    page: int                                   # Serial num of this page
+    part: str                                   # Title of this page
+    duration: int                               # Total seconds of this page
+    vid: str                                    # Identifier of outside site video
+
+
+class GetVideoInfoDataStaffItemVip(BaseModel):
+    """
+    Bilibili account's VIP status
+    """
+    vip_type: int = Field(..., alias='type')  # 0: No VIP; 1：Monthly VIP; 2: Yearly or superior VIP
+    status: int                               # 0: No VIP; 1: Has VIP
+    theme_type: int
+
+
+class GetVideoInfoDataStaffItemOfficial(BaseModel):
+    """
+    Official meta info
+    """
+    # 0: unverified
+    # 1: personal verified, famous UP
+    # 2: personal verified, V
+    # 3: organization verified, enterprise
+    # 4: organization verified, organization
+    # 5: organization verified, media
+    # 6: organization verified, government
+    # 7: personal verified, Live show host
+    # 9: personal verified, Social KOL
+    role: int
+    title: str                                     # Title of role
+    official_type: int = Field(..., alias='type')  # -1 as unverified, 0 as verified
+    desc: str = ''                                 # Verification description
+
+
+class GetVideoInfoDataStaffItem(BaseModel):
+    """
+    Bilibili account who participants in the work
+    """
+    mid: int                        # Identifier of user
+    title: str                      # Name of user
+    name: str                       # Nickname of user
+    face: str                       # Profile icon's source URL
+    vip: GetVideoInfoDataStaffItemVip
+    official: GetVideoInfoDataStaffItemOfficial
+    follower: int                   # Count of followers
+
+
+class GetVideoInfoData(BaseModel):
+    """
+    only define necessary fields
+    """
+    aid: int                                   # AV ID of video
+    bvid: str                                  # BV ID of video
+    cid: int                                   # cid of video's 1P
+    pic: str                                   # URL of video cover
+    title: str                                 # Title of video
+    desc: str                                  # legacy version video description
+    pubdate: int                               # Unix timestamp when video published (audited)
+    ctime: int                                 # Unix timestamp when video contributed
+    duration: int                              # Total seconds of video
+    staff: Optional[List[GetVideoInfoDataStaffItem]] = None
+    owner: GetVideoInfoDataOwner
+    pages: List[GetVideoInfoDataPagesItem]
+
+
+class GetVideoInfoResponse(BaseResponseModel):
+    """
+    On 'code' field,
+
+    0：success, and has 'data'
+    -400：request error
+    -403：authentication limit
+    -404：video unavailable
+    62002：video invisible
+    62004：video in review
+    """
+    data: Optional[GetVideoInfoData] = None

--- a/bili_jean/proxy_service.py
+++ b/bili_jean/proxy_service.py
@@ -1,10 +1,13 @@
 """
 Bilibili official API proxy
 """
+import json
 from typing import Dict, Optional
 
 import requests
 from requests import Response
+
+from .models import GetVideoInfoResponse
 
 
 HEADERS = {
@@ -28,12 +31,7 @@ SRC_VIDEO_INFO_URL = 'https://api.bilibili.com/x/web-interface/view'
 class ProxyService:
 
     @classmethod
-    def get_video_info(cls, bvid: Optional[str] = None, aid: Optional[int] = None) -> Response:
-        """
-        get video info which is with /video/ namespace
-        support fetching by BV or AV ID
-        (reference: https://www.bilibili.com/read/cv5167957/?spm_id_from=333.976.0.0)
-        """
+    def _get_video_info_response(cls, bvid: Optional[str] = None, aid: Optional[int] = None) -> Response:
         if all([id_val is None for id_val in (bvid, aid)]):
             raise ValueError("At least one of bvid and aid is necessary")
 
@@ -49,3 +47,14 @@ class ProxyService:
             timeout=TIMEOUT,
         )
         return response
+
+    @classmethod
+    def get_video_info(cls, bvid: Optional[str] = None, aid: Optional[int] = None) -> GetVideoInfoResponse:
+        """
+        get video info which is with /video/ namespace
+        support fetching by BV or AV ID
+        (reference: https://www.bilibili.com/read/cv5167957/?spm_id_from=333.976.0.0)
+        """
+        response = cls._get_video_info_response(bvid, aid)
+        data = json.loads(response.content.decode('utf-8'))
+        return GetVideoInfoResponse.model_validate(data)

--- a/tests/unittest/test_proxy_service.py
+++ b/tests/unittest/test_proxy_service.py
@@ -6,6 +6,8 @@ import json
 from unittest import TestCase
 from unittest.mock import patch
 
+from requests.exceptions import ReadTimeout, Timeout
+
 from bili_jean.proxy_service import ProxyService
 from tests.utils import get_mocked_response
 
@@ -23,19 +25,72 @@ class ProxyServiceTestCase(TestCase):
             json.dumps(DATA).encode('utf-8')
         )
 
-        response = ProxyService.get_video_info(bvid='BV1X54y1C74U')
+        dm = ProxyService.get_video_info(bvid='BV1X54y1C74U')
+        self.assertEqual(dm.code, DATA['code'])
+        self.assertEqual(dm.message, DATA['message'])
+        self.assertEqual(dm.ttl, DATA['ttl'])
 
-        actual_data = json.loads(response.content.decode('utf-8'))
-        self.assertDictEqual(actual_data, DATA)
+        data = dm.data
+        self.assertEqual(data.bvid, DATA['data']['bvid'])
+        self.assertEqual(data.aid, DATA['data']['aid'])
+        self.assertEqual(data.pic, DATA['data']['pic'])
+        self.assertEqual(data.title, DATA['data']['title'])
+        self.assertEqual(data.desc, DATA['data']['desc'])
+        self.assertEqual(data.duration, DATA['data']['duration'])
+        self.assertEqual(data.cid, DATA['data']['cid'])
+
+        actual_sample_page, *_ = data.pages
+        expected_sample_page, *_ = DATA['data']['pages']
+        self.assertEqual(actual_sample_page.cid, expected_sample_page['cid'])
+        self.assertEqual(actual_sample_page.page, expected_sample_page['page'])
+        self.assertEqual(actual_sample_page.part, expected_sample_page['part'])
+        self.assertEqual(actual_sample_page.duration, expected_sample_page['duration'])
+        self.assertEqual(actual_sample_page.vid, expected_sample_page['vid'])
+
+        actual_sample_owner = data.owner
+        expected_sample_owner = DATA['data']['owner']
+        self.assertEqual(actual_sample_owner.mid, expected_sample_owner['mid'])
+        self.assertEqual(actual_sample_owner.name, expected_sample_owner['name'])
+        self.assertEqual(actual_sample_owner.face, expected_sample_owner['face'])
+
+        self.assertIsNone(data.staff)
 
     @patch('bili_jean.proxy_service.requests.get')
-    def test_get_video_info_by_aid(self, mock_request):
+    def test_get_video_info_with_connection_error(self, mock_request):
+        mock_request.side_effect = ConnectionError(
+            'Max retries exceeded with url: /x/web-interface/view?bvid=BV1X54y1C74U'
+        )
+        with self.assertRaises(ConnectionError):
+            ProxyService.get_video_info(bvid='BV1X54y1C74U')
+
+    @patch('bili_jean.proxy_service.requests.get')
+    def test_get_video_info_with_timeout_error(self, mock_request):
+        mock_request.side_effect = ReadTimeout(
+            'HTTPSConnectionPool(host=\'api.bilibili.com\', port=443): Read timed out. (read timeout=5)'
+        )
+        with self.assertRaises(Timeout):
+            ProxyService.get_video_info(bvid='BV1X54y1C74U')
+
+    @patch('bili_jean.proxy_service.requests.get')
+    def test__get_video_info_response(self, mock_request):
         mock_request.return_value = get_mocked_response(
             HTTPStatus.OK.value,
             json.dumps(DATA).encode('utf-8')
         )
 
-        response = ProxyService.get_video_info(aid=842089940)
+        response = ProxyService._get_video_info_response(bvid='BV1X54y1C74U')
+
+        actual_data = json.loads(response.content.decode('utf-8'))
+        self.assertDictEqual(actual_data, DATA)
+
+    @patch('bili_jean.proxy_service.requests.get')
+    def test__get_video_info_response_by_aid(self, mock_request):
+        mock_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA).encode('utf-8')
+        )
+
+        response = ProxyService._get_video_info_response(aid=842089940)
 
         actual_data = json.loads(response.content.decode('utf-8'))
         self.assertDictEqual(actual_data, DATA)


### PR DESCRIPTION
## Changes Summary
Serialize response data of video info

## Changes Items
* define `GetVideoInfoResponse` object as data model
* integrate with ProxyService, which `get_video_info` returns data model instead of `Response`
* add unit test cases
