### PR TITLE
feat: download single page resource to local

### DIFF
--- a/bili_jean/constants.py
+++ b/bili_jean/constants.py
@@ -176,3 +176,41 @@ WEB_VIEW_URL_ID_TYPE_MAPPING = {
     WEB_VIEW_URL_PUGV_EPID_PATTERN: StreamingIDType.EP_ID,
     WEB_VIEW_URL_PUGV_SSID_PATTERN: StreamingIDType.SEASON_ID
 }
+
+
+class VideoCodecID(IntEnum):
+    """
+    AVC, which is avc1.64001E, not support 8K
+    HEVC, which is hev1.1.6.L120.90
+    AV1, which is av01.0.00M.10.0.110.01.01.01.0
+    """
+    AVC = 7
+    HEVC = 12
+    AV1 = 13
+
+    @classmethod
+    def from_value(cls, codec_id: int) -> 'VideoCodecID':
+        for item in cls:
+            if item == codec_id:
+                return item
+        raise ValueError(f'Invalid given video codec ID: {codec_id}')
+
+
+class AudioBitRateID(IntEnum):
+    """
+    AVC, which is avc1.64001E, not support 8K
+    HEVC, which is hev1.1.6.L120.90
+    AV1, which is av01.0.00M.10.0.110.01.01.01.0
+    """
+    BPS_64 = 30216
+    BPS_132 = 30232
+    BPS_192 = 30280
+    BPS_DOLBY = 30250
+    BPS_HIRES = 30251
+
+    @classmethod
+    def from_value(cls, bitrate_id: int) -> 'AudioBitRateID':
+        for item in cls:
+            if item == bitrate_id:
+                return item
+        raise ValueError(f'Invalid given audio bitrate ID: {bitrate_id}')

--- a/bili_jean/constants.py
+++ b/bili_jean/constants.py
@@ -228,3 +228,27 @@ class AudioBitRateID(Enum):
             if item.value.bit_rate_id == bitrate_id:
                 return item
         raise ValueError(f'Invalid given audio bitrate ID: {bitrate_id}')
+
+
+HEADERS = {
+    'origin': 'https://www.bilibili.com',
+    'referer': 'https://www.bilibili.com/',
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+                  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    'accept': 'application/json, text/plain, */*',
+    'Sec-Ch-Ua': '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
+    'Sec-Ch-Ua-Mobile': '?0',
+    'Sec-Ch-Ua-Platform': '"macOS"',
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'same-site'
+}
+TIMEOUT = 5
+
+
+URL_WEB_PGC_PLAY = 'https://api.bilibili.com/pgc/player/web/playurl'
+URL_WEB_PGC_VIEW = 'https://api.bilibili.com/pgc/view/web/season'
+URL_WEB_PUGV_PLAY = 'https://api.bilibili.com/pugv/player/web/playurl'
+URL_WEB_PUGV_VIEW = 'https://api.bilibili.com/pugv/view/web/season'
+URL_WEB_UGC_PLAY = 'https://api.bilibili.com/x/player/wbi/playurl'
+URL_WEB_UGC_VIEW = 'https://api.bilibili.com/x/web-interface/view'

--- a/bili_jean/constants.py
+++ b/bili_jean/constants.py
@@ -148,6 +148,13 @@ class StreamingCategory(Enum):
     PGC = 'pgc'
     PUGV = 'pugv'
 
+    @classmethod
+    def from_value(cls, category: str) -> 'StreamingCategory':
+        for item in cls:
+            if item.value == category:
+                return item
+        raise ValueError(f'Invalid given streaming category: {category}')
+
 
 class StreamingIDType(Enum):
     """

--- a/bili_jean/constants.py
+++ b/bili_jean/constants.py
@@ -4,6 +4,7 @@ Constants components
 from enum import Enum, IntEnum
 from functools import reduce
 import re
+from typing import NamedTuple
 
 
 class QualityNumber(IntEnum):
@@ -196,21 +197,27 @@ class VideoCodecID(IntEnum):
         raise ValueError(f'Invalid given video codec ID: {codec_id}')
 
 
-class AudioBitRateID(IntEnum):
+class AudioBitRateItem(NamedTuple):
+
+    bit_rate_id: int
+    quality: int
+
+
+class AudioBitRateID(Enum):
     """
     AVC, which is avc1.64001E, not support 8K
     HEVC, which is hev1.1.6.L120.90
     AV1, which is av01.0.00M.10.0.110.01.01.01.0
     """
-    BPS_64K = 30216
-    BPS_132K = 30232
-    BPS_192K = 30280
-    BPS_DOLBY = 30250
-    BPS_HIRES = 30251
+    BPS_64K = AudioBitRateItem(bit_rate_id=30216, quality=1)
+    BPS_132K = AudioBitRateItem(bit_rate_id=30232, quality=2)
+    BPS_192K = AudioBitRateItem(bit_rate_id=30280, quality=3)
+    BPS_DOLBY = AudioBitRateItem(bit_rate_id=30250, quality=4)
+    BPS_HIRES = AudioBitRateItem(bit_rate_id=30251, quality=5)
 
     @classmethod
     def from_value(cls, bitrate_id: int) -> 'AudioBitRateID':
         for item in cls:
-            if item == bitrate_id:
+            if item.value.bit_rate_id == bitrate_id:
                 return item
         raise ValueError(f'Invalid given audio bitrate ID: {bitrate_id}')

--- a/bili_jean/constants.py
+++ b/bili_jean/constants.py
@@ -202,9 +202,9 @@ class AudioBitRateID(IntEnum):
     HEVC, which is hev1.1.6.L120.90
     AV1, which is av01.0.00M.10.0.110.01.01.01.0
     """
-    BPS_64 = 30216
-    BPS_132 = 30232
-    BPS_192 = 30280
+    BPS_64K = 30216
+    BPS_132K = 30232
+    BPS_192K = 30280
     BPS_DOLBY = 30250
     BPS_HIRES = 30251
 

--- a/bili_jean/page_download_service.py
+++ b/bili_jean/page_download_service.py
@@ -1,0 +1,70 @@
+"""
+Service component for download remote resource to local
+"""
+import copy
+from http import HTTPStatus
+from pathlib import Path
+from typing import Optional
+
+from .constants import HEADERS
+from .proxy_service import ProxyService
+
+
+class DownloadError(Exception):
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class PageDownloadService:
+
+    def __init__(self, url: str, file: str):
+        self._url = url
+        self._path = Path(file)
+        if self._path.is_dir():
+            raise ValueError('The value of \'file\' should be a file path')
+        self._tmp_ext_suffix = '.part'
+        self._tmp_path = Path(''.join([str(self._path), self._tmp_ext_suffix]))
+        self._remote_file_size: Optional[int] = None
+
+    @property
+    def remote_file_size(self) -> int:
+        if self._remote_file_size is None:
+            response = ProxyService.head(url=self._url)
+            if response.status_code not in (HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT):
+                raise DownloadError(
+                    f'Error {response.status_code} when get content length: '
+                    f"{response.content.decode('utf-8')}"
+                )
+            self._remote_file_size = int(response.headers.get('Content-Length', 0))
+        return self._remote_file_size
+
+    def download(self) -> None:
+        """
+        1. create directory if not exists
+        2. compared local temporary file's size with remote one,
+           and continue to download the rest of it
+        3. change temporary file to normal
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        file_size = 0
+        if self._tmp_path.exists():
+            file_size = self._tmp_path.stat().st_size
+
+        if file_size < self.remote_file_size:
+            headers = copy.deepcopy(HEADERS)
+            headers.update({"Range": f"bytes={file_size}-"})
+
+            response = ProxyService.get(url=self._url, headers=headers, stream=True)
+            if response.status_code not in (HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT):
+                raise DownloadError(
+                    f"Error {response.status_code} when download resource: "
+                    f"{response.content.decode('utf-8')}"
+                )
+            with open(str(self._tmp_path.resolve()), 'ab') as f:
+                for chunk in response.iter_content(chunk_size=1024):
+                    f.write(chunk)
+
+        self._tmp_path.rename(self._path)

--- a/bili_jean/proxy_service.py
+++ b/bili_jean/proxy_service.py
@@ -6,7 +6,17 @@ from typing import Dict, Optional
 
 from requests import Response, session
 
-from .constants import FormatNumberValue
+from .constants import (
+    FormatNumberValue,
+    HEADERS,
+    TIMEOUT,
+    URL_WEB_PGC_PLAY,
+    URL_WEB_PGC_VIEW,
+    URL_WEB_PUGV_PLAY,
+    URL_WEB_PUGV_VIEW,
+    URL_WEB_UGC_PLAY,
+    URL_WEB_UGC_VIEW
+)
 from .schemes import (
     GetPGCPlayResponse,
     GetPGCViewResponse,
@@ -18,30 +28,6 @@ from .schemes import (
 
 
 __all__ = ['ProxyService']
-
-
-HEADERS = {
-    'origin': 'https://www.bilibili.com',
-    'referer': 'https://www.bilibili.com/',
-    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
-                  'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-    'accept': 'application/json, text/plain, */*',
-    'Sec-Ch-Ua': '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
-    'Sec-Ch-Ua-Mobile': '?0',
-    'Sec-Ch-Ua-Platform': '"macOS"',
-    'Sec-Fetch-Dest': 'empty',
-    'Sec-Fetch-Mode': 'cors',
-    'Sec-Fetch-Site': 'same-site'
-}
-TIMEOUT = 5
-
-
-URL_WEB_PGC_PLAY = 'https://api.bilibili.com/pgc/player/web/playurl'
-URL_WEB_PGC_VIEW = 'https://api.bilibili.com/pgc/view/web/season'
-URL_WEB_PUGV_PLAY = 'https://api.bilibili.com/pugv/player/web/playurl'
-URL_WEB_PUGV_VIEW = 'https://api.bilibili.com/pugv/view/web/season'
-URL_WEB_UGC_PLAY = 'https://api.bilibili.com/x/player/wbi/playurl'
-URL_WEB_UGC_VIEW = 'https://api.bilibili.com/x/web-interface/view'
 
 
 class ProxyService:

--- a/bili_jean/proxy_service.py
+++ b/bili_jean/proxy_service.py
@@ -53,7 +53,8 @@ class ProxyService:
         params: Optional[Dict] = None,
         sess_data: Optional[str] = None,
         timeout: int = TIMEOUT,
-        allow_redirects: bool = True
+        allow_redirects: bool = True,
+        stream: bool = False
     ) -> Response:
         s = session()
         if sess_data is not None:
@@ -63,7 +64,8 @@ class ProxyService:
             params=params,
             headers=HEADERS,
             timeout=timeout,
-            allow_redirects=allow_redirects
+            allow_redirects=allow_redirects,
+            stream=stream
         )
 
     @classmethod

--- a/bili_jean/proxy_service.py
+++ b/bili_jean/proxy_service.py
@@ -37,6 +37,7 @@ class ProxyService:
         cls,
         url: str,
         params: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
         sess_data: Optional[str] = None,
         timeout: int = TIMEOUT,
         allow_redirects: bool = True,
@@ -45,14 +46,25 @@ class ProxyService:
         s = session()
         if sess_data is not None:
             s.cookies.set('SESSDATA', sess_data)
+        if headers is None:
+            headers = HEADERS
         return s.get(
             url,
             params=params,
-            headers=HEADERS,
+            headers=headers,
             timeout=timeout,
             allow_redirects=allow_redirects,
             stream=stream
         )
+
+    @classmethod
+    def head(
+        cls,
+        url: str,
+        timeout: int = TIMEOUT
+    ) -> Response:
+        s = session()
+        return s.head(url, headers=HEADERS, timeout=timeout)
 
     @classmethod
     def get_ugc_view(

--- a/bili_jean/schemes/__init__.py
+++ b/bili_jean/schemes/__init__.py
@@ -7,4 +7,9 @@ from .proxy.pugv_play import GetPUGVPlayResponse  # NOQA
 from .proxy.pugv_view import GetPUGVViewResponse  # NOQA
 from .proxy.ugc_play import GetUGCPlayResponse  # NOQA
 from .proxy.ugc_view import GetUGCViewResponse  # NOQA
-from .streaming import Page, StreamingWebViewMeta  # NOQA
+from .streaming import (  # NOQA
+    AudioStreamingSourceMeta,
+    Page,
+    StreamingWebViewMeta,
+    VideoStreamingSourceMeta
+)

--- a/bili_jean/schemes/__init__.py
+++ b/bili_jean/schemes/__init__.py
@@ -1,6 +1,7 @@
 """
 Scheme definitions of the cross-project objects
 """
+from .proxy.base import DashMediaItem  # NOQA
 from .proxy.pgc_play import GetPGCPlayResponse  # NOQA
 from .proxy.pgc_view import GetPGCViewResponse  # NOQA
 from .proxy.pugv_play import GetPUGVPlayResponse  # NOQA

--- a/bili_jean/schemes/proxy/base.py
+++ b/bili_jean/schemes/proxy/base.py
@@ -1,9 +1,9 @@
 """
 Scheme definition of the Bilibili API response
 """
-from typing import Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class BaseResponseModel(BaseModel):
@@ -13,3 +13,18 @@ class BaseResponseModel(BaseModel):
     code: int = 0              # status code
     message: str = '0'         # error message
     ttl: Optional[int] = None
+
+
+class DashMediaItem(BaseModel):
+    """
+    Digital media data
+    """
+    backup_url: List[str]                   # URLs of backup resources
+    bandwidth: int                          # minimum of network bandwidth that needed
+    base_url: str                           # resource URL
+    codecid: int
+    codecs: str
+    height: int                             # 0 for audio
+    id_field: int = Field(..., alias='id')
+    mime_type: str
+    width: int                              # 0 for audio

--- a/bili_jean/schemes/proxy/pgc_play.py
+++ b/bili_jean/schemes/proxy/pgc_play.py
@@ -5,29 +5,14 @@ from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .base import BaseResponseModel
-
-
-class GetPGCPlayResultDashMediaItem(BaseModel):
-    """
-    PGC digital media data
-    """
-    backup_url: List[str]                   # URLs of backup resources
-    bandwidth: int                          # minimum of network bandwidth that needed
-    base_url: str                           # resource URL
-    codecid: int
-    codecs: str
-    height: int                             # 0 for audio
-    id_field: int = Field(..., alias='id')
-    mime_type: str
-    width: int                              # 0 for audio
+from .base import BaseResponseModel, DashMediaItem
 
 
 class GetPGCPlayResultDashDolby(BaseModel):
     """
     Dolby audio data
     """
-    audio: List[GetPGCPlayResultDashMediaItem] = []
+    audio: List[DashMediaItem] = []
     # 1 is normal, 2 is panoramic
     # for cheese, could be 'NONE'
     type_field: Union[int, str] = Field(..., alias='type')
@@ -37,19 +22,19 @@ class GetPGCPlayResultDashFlac(BaseModel):
     """
     Hi-Res audio data
     """
-    audio: Optional[GetPGCPlayResultDashMediaItem] = None
-    display: bool                                        # illustrate Hi-Res or not
+    audio: Optional[DashMediaItem] = None
+    display: bool                          # illustrate Hi-Res or not
 
 
 class GetPGCPlayResultDash(BaseModel):
     """
     PGC stream play's DASH
     """
-    audio: Optional[List[GetPGCPlayResultDashMediaItem]] = None  # null when resource has no audio
-    dolby: GetPGCPlayResultDashDolby                             # Dolby audio
-    duration: int                                                # resource duration which unit is second
-    flac: Optional[GetPGCPlayResultDashFlac] = None              # High quality audio
-    video: List[GetPGCPlayResultDashMediaItem]                   # video
+    audio: Optional[List[DashMediaItem]] = None      # null when resource has no audio
+    dolby: GetPGCPlayResultDashDolby                 # Dolby audio
+    duration: int                                    # resource duration which unit is second
+    flac: Optional[GetPGCPlayResultDashFlac] = None  # High quality audio
+    video: List[DashMediaItem]                       # video
 
 
 class GetPGCPlayResultDUrlItem(BaseModel):

--- a/bili_jean/schemes/proxy/pugv_play.py
+++ b/bili_jean/schemes/proxy/pugv_play.py
@@ -5,37 +5,22 @@ from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .base import BaseResponseModel
-
-
-class GetPUGVPlayDataDashMediaItem(BaseModel):
-    """
-    PUGV digital media data
-    """
-    backup_url: List[str]                   # URLs of backup resources
-    bandwidth: int                          # minimum of network bandwidth that needed
-    base_url: str                           # resource URL
-    codecid: int
-    codecs: str
-    height: int                             # 0 for audio
-    id_field: int = Field(..., alias='id')
-    mime_type: str
-    width: int                              # 0 for audio
+from .base import BaseResponseModel, DashMediaItem
 
 
 class GetPUGVPlayDataDashFlac(BaseModel):
     """
     Hi-Res audio data
     """
-    audio: Optional[GetPUGVPlayDataDashMediaItem] = None
-    display: bool                                         # illustrate Hi-Res or not
+    audio: Optional[DashMediaItem] = None
+    display: bool                          # illustrate Hi-Res or not
 
 
 class GetPUGVPlayDataDashDolby(BaseModel):
     """
     Dolby audio data
     """
-    audio: List[GetPUGVPlayDataDashMediaItem] = []
+    audio: List[DashMediaItem] = []
     # 1 is normal, 2 is panoramic
     # for cheese, could be 'NONE'
     type_field: Union[int, str] = Field(..., alias='type')
@@ -45,11 +30,11 @@ class GetPUGVPlayDataDash(BaseModel):
     """
     PUGV stream play's DASH
     """
-    audio: Optional[List[GetPUGVPlayDataDashMediaItem]] = None  # null when resource has no audio
-    dolby: GetPUGVPlayDataDashDolby                             # Dolby audio
-    duration: int                                               # resource duration which unit is second
-    flac: Optional[GetPUGVPlayDataDashFlac] = None              # High quality audio
-    video: List[GetPUGVPlayDataDashMediaItem]                   # video
+    audio: Optional[List[DashMediaItem]] = None     # null when resource has no audio
+    dolby: GetPUGVPlayDataDashDolby                 # Dolby audio
+    duration: int                                   # resource duration which unit is second
+    flac: Optional[GetPUGVPlayDataDashFlac] = None  # High quality audio
+    video: List[DashMediaItem]                      # video
 
 
 class GetPUGVPlayDataDUrlItem(BaseModel):

--- a/bili_jean/schemes/proxy/ugc_play.py
+++ b/bili_jean/schemes/proxy/ugc_play.py
@@ -5,37 +5,22 @@ from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .base import BaseResponseModel
-
-
-class GetUGCPlayDataDashMediaItem(BaseModel):
-    """
-    UGC digital media data
-    """
-    backup_url: List[str]                   # URLs of backup resources
-    bandwidth: int                          # minimum of network bandwidth that needed
-    base_url: str                           # resource URL
-    codecid: int
-    codecs: str
-    height: int                             # 0 for audio
-    id_field: int = Field(..., alias='id')
-    mime_type: str
-    width: int                              # 0 for audio
+from .base import BaseResponseModel, DashMediaItem
 
 
 class GetUGCPlayDataDashFlac(BaseModel):
     """
     Hi-Res audio data
     """
-    audio: Optional[GetUGCPlayDataDashMediaItem] = None
-    display: bool                                        # illustrate Hi-Res or not
+    audio: Optional[DashMediaItem] = None
+    display: bool                          # illustrate Hi-Res or not
 
 
 class GetUGCPlayDataDashDolby(BaseModel):
     """
     Dolby audio data
     """
-    audio: Optional[List[GetUGCPlayDataDashMediaItem]] = None
+    audio: Optional[List[DashMediaItem]] = None
     # 1 is normal, 2 is panoramic
     # for cheese, could be 'NONE'
     type_field: Union[int, str] = Field(..., alias='type')
@@ -45,11 +30,11 @@ class GetUGCPlayDataDash(BaseModel):
     """
     UGC stream play's DASH
     """
-    audio: Optional[List[GetUGCPlayDataDashMediaItem]] = None  # null when resource has no audio
-    dolby: GetUGCPlayDataDashDolby                             # Dolby audio
-    duration: int                                              # resource duration which unit is second
-    flac: Optional[GetUGCPlayDataDashFlac] = None              # High quality audio
-    video: List[GetUGCPlayDataDashMediaItem]                   # video
+    audio: Optional[List[DashMediaItem]] = None    # null when resource has no audio
+    dolby: GetUGCPlayDataDashDolby                 # Dolby audio
+    duration: int                                  # resource duration which unit is second
+    flac: Optional[GetUGCPlayDataDashFlac] = None  # High quality audio
+    video: List[DashMediaItem]                     # video
 
 
 class GetUGCPlayDataDUrlItem(BaseModel):

--- a/bili_jean/schemes/streaming.py
+++ b/bili_jean/schemes/streaming.py
@@ -63,3 +63,18 @@ class StreamingWebViewMeta(BaseModel):
     bvid: Optional[str] = None
     ep_id: Optional[int] = None
     season_id: Optional[int] = None
+
+
+class AudioStreamingSourceMeta(BaseModel):
+
+    url: str
+    mime_type: str
+    qn: int
+
+
+class VideoStreamingSourceMeta(BaseModel):
+
+    codec_id: int
+    mime_type: str
+    qn: int
+    url: str

--- a/bili_jean/streaming/components/base.py
+++ b/bili_jean/streaming/components/base.py
@@ -36,7 +36,7 @@ class AbstractStreamingComponent(ABC):
         """
         play_dm = cls._get_play(*args, **kwargs)
         if play_dm.code != 0:
-            raise
+            raise ValueError(f'request play data error: {play_dm.message}')
 
         is_video_hq_preferred = kwargs.get('is_video_hq_preferred')
         if is_video_hq_preferred is None:

--- a/bili_jean/streaming/components/base.py
+++ b/bili_jean/streaming/components/base.py
@@ -2,9 +2,17 @@
 Base streaming component
 """
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple, Union
 
-from ...schemes import Page
+from ...schemes import (
+    AudioStreamingSourceMeta,
+    DashMediaItem,
+    GetPGCPlayResponse,
+    GetPUGVPlayResponse,
+    GetUGCPlayResponse,
+    Page,
+    VideoStreamingSourceMeta
+)
 
 
 class AbstractStreamingComponent(ABC):
@@ -17,8 +25,122 @@ class AbstractStreamingComponent(ABC):
         """
 
     @classmethod
-    @abstractmethod
-    def get_page_streaming_src(cls, *args: Any, **kwargs: Any):
+    def get_page_streaming_src(
+        cls,
+        *args: Any,
+        **kwargs: Any
+    ) -> Tuple[VideoStreamingSourceMeta, AudioStreamingSourceMeta]:
         """
         get source URL of streaming, including both video and audio
+        """
+        play_dm = cls._get_play(*args, **kwargs)
+        if play_dm.code != 0:
+            raise
+
+        is_video_hq_preferred = kwargs.get('is_video_hq_preferred')
+        if is_video_hq_preferred is None:
+            is_video_hq_preferred = True
+        is_video_codec_eff_preferred = kwargs.get('is_video_codec_eff_preferred')
+        if is_video_codec_eff_preferred is None:
+            is_video_codec_eff_preferred = True
+        video_src = cls._get_play_video_src(
+            media_items=cls._get_play_video_pool(play_dm=play_dm),
+            is_hq_preferred=is_video_hq_preferred,
+            qn=kwargs.get('video_qn'),
+            is_codec_eff_preferred=is_video_codec_eff_preferred,
+            codec_id=kwargs.get('video_codec_number')
+        )
+
+        is_audio_hq_preferred = kwargs.get('is_audio_hq_preferred')
+        if is_audio_hq_preferred is None:
+            is_audio_hq_preferred = True
+        audio_src = cls._get_play_audio_src(
+            media_items=cls._get_play_audio_pool(play_dm=play_dm),
+            is_hq_preferred=is_audio_hq_preferred,
+            qn=kwargs.get('audio_qn')
+        )
+        return video_src, audio_src
+
+    @classmethod
+    @abstractmethod
+    def _get_play(
+        cls,
+        *args: Any,
+        **kwargs: Any
+    ) -> Union[GetPGCPlayResponse, GetPUGVPlayResponse, GetUGCPlayResponse]:
+        """
+        get play response data model
+        """
+
+    @classmethod
+    def _get_play_video_src(
+        cls,
+        media_items: List[DashMediaItem],
+        is_hq_preferred: bool = True,
+        qn: Optional[int] = None,
+        is_codec_eff_preferred: bool = True,
+        codec_id: Optional[int] = None
+    ) -> VideoStreamingSourceMeta:
+        avail_hqs: List[int] = list(set([item.id_field for item in media_items]))
+        avail_hqs.sort(reverse=is_hq_preferred)
+        if qn is not None:
+            avail_hqs = [avail_hq for avail_hq in avail_hqs if avail_hq <= qn]
+            if avail_hqs:
+                avail_hqs.sort(reverse=True)
+        qn, *_ = avail_hqs
+        media_items = [item for item in media_items if item.id_field == qn]
+
+        avail_codec_ids: List[int] = list(set([item.codecid for item in media_items]))
+        avail_codec_ids.sort(reverse=is_codec_eff_preferred)
+        if codec_id is not None:
+            avail_codec_ids = [avail_codec_id for avail_codec_id in avail_codec_ids if avail_codec_id <= codec_id]
+            if avail_codec_ids:
+                avail_codec_ids.sort(reverse=True)
+        codec_id, *_ = avail_codec_ids
+        media, *_ = [item for item in media_items if item.codecid == codec_id]
+        return VideoStreamingSourceMeta(
+            url=media.base_url,
+            codec_id=media.codecid,
+            qn=media.id_field,
+            mime_type=media.mime_type
+        )
+
+    @classmethod
+    def _get_play_audio_src(
+        cls,
+        media_items: List[DashMediaItem],
+        is_hq_preferred: bool = True,
+        qn: Optional[int] = None
+    ) -> AudioStreamingSourceMeta:
+        avail_bitrates = list(set([media_item.id_field for media_item in media_items]))
+        avail_bitrates.sort(reverse=is_hq_preferred)
+        if qn is not None:
+            avail_bitrates = [
+                avail_bitrate for avail_bitrate in avail_bitrates
+                if avail_bitrate <= qn
+            ]
+            if avail_bitrates:
+                avail_bitrates.sort(reverse=True)
+        qn, *_ = avail_bitrates
+        media, *_ = [item for item in media_items if item.id_field == qn]
+        return AudioStreamingSourceMeta(
+            url=media.base_url,
+            qn=media.id_field,
+            mime_type=media.mime_type
+        )
+
+    @classmethod
+    @abstractmethod
+    def _get_play_video_pool(cls, *args: Any, **kwargs: Any) -> List[DashMediaItem]:
+        """
+        get list of media items about video resource
+        :key play_dm: data model of the response from Play endpoint
+        """
+
+    @classmethod
+    @abstractmethod
+    def _get_play_audio_pool(cls, *args: Any, **kwargs: Any) -> List[DashMediaItem]:
+        """
+        get list of media items about audio resource
+        :key play_dm: data model of the response from Play endpoint
         """

--- a/bili_jean/streaming/components/base.py
+++ b/bili_jean/streaming/components/base.py
@@ -15,3 +15,10 @@ class AbstractStreamingComponent(ABC):
         """
         get normalized views info
         """
+
+    @classmethod
+    @abstractmethod
+    def get_page_streaming_src(cls, *args: Any, **kwargs: Any):
+        """
+        get source URL of streaming, including both video and audio
+        """

--- a/bili_jean/streaming/components/pgc.py
+++ b/bili_jean/streaming/components/pgc.py
@@ -1,11 +1,18 @@
 """
 Manipulate PGC resources
 """
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Tuple, Union
 
-from ...constants import StreamingCategory
+from ...constants import FormatNumberValue, StreamingCategory
 from ...proxy_service import ProxyService
-from ...schemes import GetPGCViewResponse, Page
+from ...schemes import (
+    AudioStreamingSourceMeta,
+    GetPGCPlayResponse,
+    GetPGCViewResponse,
+    Page,
+    VideoStreamingSourceMeta
+)
+from ...schemes.proxy.pgc_play import GetPGCPlayResultDashMediaItem
 from ...schemes.proxy.pgc_view import (
     GetPGCViewResultEpisodesItem,
     GetPGCViewResultSectionEpisodesItem
@@ -142,3 +149,132 @@ class PGCComponent(AbstractStreamingComponent):
         episode: Union[GetPGCViewResultEpisodesItem, GetPGCViewResultSectionEpisodesItem]
     ) -> str:
         return ' '.join((episode.title or '', episode.long_title or '')).strip()
+
+    @classmethod
+    def get_page_streaming_src(
+        cls,
+        *args: Any,
+        **kwargs: Any
+    ) -> Tuple[VideoStreamingSourceMeta, AudioStreamingSourceMeta]:
+        """
+        :key cid: cid of a PGC resource, type is int, optional
+        :key ep_id: ep_id of a PGC resource, type is int, optional
+        :key is_video_hq_preferred: prefer high quality video or not, type is bool, default is True
+        :key video_qn: quality number, optional, prior to is_video_hq_preferred if declared
+        :key is_video_codec_eff_preferred: prefer higher efficiency codec or not,
+                                           type is bool, default is True
+                                           which means AV1 > HEVC > AVC
+        :key video_codec_number: codec number of video, optional, prior to is_video_codec_eff_preferred if declared
+        :key is_audio_hq_preferred: prefer high quality audio or not, type is bool, default is True
+        :key audio_qn: audio quality number, optional, prior to is_audio_hq_preferred if declared
+        :key sess_data: cookie of Bilibili user which key is SESSDATA, type is str
+        """
+        cid = kwargs.get('cid')
+        ep_id = kwargs.get('ep_id')
+        if all([id_val is None for id_val in (cid, ep_id)]):
+            raise ValueError("At least one of cid and ep_id is necessary")
+
+        params = {}
+        if cid is not None:
+            params.update({'cid': cid})
+        else:
+            params.update({'ep_id': ep_id})
+        params.update({
+            'fnval': FormatNumberValue.full_format(),
+            'fourk': 1,
+            'sess_data': kwargs.get('sess_data')
+        })
+
+        pgc_play = ProxyService.get_pgc_play(**params)
+
+        if pgc_play.code != 0:
+            raise
+
+        is_video_hq_preferred = kwargs.get('is_video_hq_preferred')
+        if is_video_hq_preferred is None:
+            is_video_hq_preferred = True
+        is_video_codec_eff_preferred = kwargs.get('is_video_codec_eff_preferred')
+        if is_video_codec_eff_preferred is None:
+            is_video_codec_eff_preferred = True
+        video_src = cls._parse_page_play_video_src(
+            pgc_play=pgc_play,
+            is_hq_preferred=is_video_hq_preferred,
+            qn=kwargs.get('video_qn'),
+            is_codec_eff_preferred=is_video_codec_eff_preferred,
+            codec_number=kwargs.get('video_codec_number')
+        )
+
+        is_audio_hq_preferred = kwargs.get('is_audio_hq_preferred')
+        if is_audio_hq_preferred is None:
+            is_audio_hq_preferred = True
+        audio_src = cls._parse_page_play_audio_src(
+            pgc_play=pgc_play,
+            is_hq_preferred=is_audio_hq_preferred,
+            qn=kwargs.get('audio_qn')
+        )
+        return video_src, audio_src
+
+    @classmethod
+    def _parse_page_play_video_src(
+        cls,
+        pgc_play: GetPGCPlayResponse,
+        is_hq_preferred: bool = True,
+        qn: Optional[int] = None,
+        is_codec_eff_preferred: bool = True,
+        codec_number: Optional[int] = None
+    ) -> VideoStreamingSourceMeta:
+        source_pool: List[GetPGCPlayResultDashMediaItem] = pgc_play.result.dash.video
+
+        avail_hqs: List[int] = list(set([item.id_field for item in source_pool]))
+        avail_hqs.sort(reverse=is_hq_preferred)
+        if qn is not None:
+            avail_hqs = [avail_hq for avail_hq in avail_hqs if avail_hq <= qn]
+            if avail_hqs:
+                avail_hqs.sort(reverse=True)
+        qn, *_ = avail_hqs
+        source_pool = list(filter(lambda item: item.id_field == qn, source_pool))
+
+        avail_codecs: List[int] = list(set([item.codecid for item in source_pool]))
+        avail_codecs.sort(reverse=is_codec_eff_preferred)
+        if codec_number is not None:
+            avail_codecs = [avail_codec for avail_codec in avail_codecs if avail_codec <= codec_number]
+            if avail_codecs:
+                avail_codecs.sort(reverse=True)
+        codec_id, *_ = avail_codecs
+        media, *_ = list(filter(lambda item: item.codecid == codec_id, source_pool))
+        return VideoStreamingSourceMeta(
+            url=media.base_url,
+            codec_id=media.codecid,
+            qn=media.id_field,
+            mime_type=media.mime_type
+        )
+
+    @classmethod
+    def _parse_page_play_audio_src(
+        cls,
+        pgc_play: GetPGCPlayResponse,
+        is_hq_preferred: bool = True,
+        qn: Optional[int] = None
+    ) -> AudioStreamingSourceMeta:
+        dash = pgc_play.result.dash
+        source_pool: List[GetPGCPlayResultDashMediaItem] = []
+        if dash.dolby.audio is not None and len(dash.dolby.audio) > 0:
+            source_pool.extend(dash.dolby.audio)
+        if dash.flac is not None and dash.flac.audio is not None:
+            source_pool.append(dash.flac.audio)
+        if dash.audio is not None:
+            source_pool.extend(dash.audio)
+
+        avail_bitrates = list(set([item.id_field for item in source_pool]))
+        avail_bitrates.sort(reverse=is_hq_preferred)
+        if qn is not None:
+            avail_bitrates = [avail_bitrate for avail_bitrate in avail_bitrates if avail_bitrate <= qn]
+            if avail_bitrates:
+                avail_bitrates.sort(reverse=True)
+        qn, *_ = avail_bitrates
+        media, *_ = [item for item in source_pool if item.id_field == qn]
+        return AudioStreamingSourceMeta(
+            url=media.base_url,
+            qn=media.id_field,
+            mime_type=media.mime_type
+        )

--- a/bili_jean/streaming/components/pgc.py
+++ b/bili_jean/streaming/components/pgc.py
@@ -7,12 +7,12 @@ from ...constants import FormatNumberValue, StreamingCategory
 from ...proxy_service import ProxyService
 from ...schemes import (
     AudioStreamingSourceMeta,
+    DashMediaItem,
     GetPGCPlayResponse,
     GetPGCViewResponse,
     Page,
     VideoStreamingSourceMeta
 )
-from ...schemes.proxy.pgc_play import GetPGCPlayResultDashMediaItem
 from ...schemes.proxy.pgc_view import (
     GetPGCViewResultEpisodesItem,
     GetPGCViewResultSectionEpisodesItem
@@ -169,6 +169,14 @@ class PGCComponent(AbstractStreamingComponent):
         :key audio_qn: audio quality number, optional, prior to is_audio_hq_preferred if declared
         :key sess_data: cookie of Bilibili user which key is SESSDATA, type is str
         """
+        return super().get_page_streaming_src(*args, **kwargs)
+
+    @classmethod
+    def _get_play(
+        cls,
+        *args: Any,
+        **kwargs: Any
+    ) -> GetPGCPlayResponse:
         cid = kwargs.get('cid')
         ep_id = kwargs.get('ep_id')
         if all([id_val is None for id_val in (cid, ep_id)]):
@@ -186,95 +194,22 @@ class PGCComponent(AbstractStreamingComponent):
         })
 
         pgc_play = ProxyService.get_pgc_play(**params)
-
-        if pgc_play.code != 0:
-            raise
-
-        is_video_hq_preferred = kwargs.get('is_video_hq_preferred')
-        if is_video_hq_preferred is None:
-            is_video_hq_preferred = True
-        is_video_codec_eff_preferred = kwargs.get('is_video_codec_eff_preferred')
-        if is_video_codec_eff_preferred is None:
-            is_video_codec_eff_preferred = True
-        video_src = cls._parse_page_play_video_src(
-            pgc_play=pgc_play,
-            is_hq_preferred=is_video_hq_preferred,
-            qn=kwargs.get('video_qn'),
-            is_codec_eff_preferred=is_video_codec_eff_preferred,
-            codec_number=kwargs.get('video_codec_number')
-        )
-
-        is_audio_hq_preferred = kwargs.get('is_audio_hq_preferred')
-        if is_audio_hq_preferred is None:
-            is_audio_hq_preferred = True
-        audio_src = cls._parse_page_play_audio_src(
-            pgc_play=pgc_play,
-            is_hq_preferred=is_audio_hq_preferred,
-            qn=kwargs.get('audio_qn')
-        )
-        return video_src, audio_src
+        return pgc_play
 
     @classmethod
-    def _parse_page_play_video_src(
-        cls,
-        pgc_play: GetPGCPlayResponse,
-        is_hq_preferred: bool = True,
-        qn: Optional[int] = None,
-        is_codec_eff_preferred: bool = True,
-        codec_number: Optional[int] = None
-    ) -> VideoStreamingSourceMeta:
-        source_pool: List[GetPGCPlayResultDashMediaItem] = pgc_play.result.dash.video
-
-        avail_hqs: List[int] = list(set([item.id_field for item in source_pool]))
-        avail_hqs.sort(reverse=is_hq_preferred)
-        if qn is not None:
-            avail_hqs = [avail_hq for avail_hq in avail_hqs if avail_hq <= qn]
-            if avail_hqs:
-                avail_hqs.sort(reverse=True)
-        qn, *_ = avail_hqs
-        source_pool = list(filter(lambda item: item.id_field == qn, source_pool))
-
-        avail_codecs: List[int] = list(set([item.codecid for item in source_pool]))
-        avail_codecs.sort(reverse=is_codec_eff_preferred)
-        if codec_number is not None:
-            avail_codecs = [avail_codec for avail_codec in avail_codecs if avail_codec <= codec_number]
-            if avail_codecs:
-                avail_codecs.sort(reverse=True)
-        codec_id, *_ = avail_codecs
-        media, *_ = list(filter(lambda item: item.codecid == codec_id, source_pool))
-        return VideoStreamingSourceMeta(
-            url=media.base_url,
-            codec_id=media.codecid,
-            qn=media.id_field,
-            mime_type=media.mime_type
-        )
+    def _get_play_video_pool(cls, *args: Any, **kwargs: Any) -> List[DashMediaItem]:  # NOQA
+        play_dm: GetPGCPlayResponse = kwargs['play_dm']
+        return play_dm.result.dash.video
 
     @classmethod
-    def _parse_page_play_audio_src(
-        cls,
-        pgc_play: GetPGCPlayResponse,
-        is_hq_preferred: bool = True,
-        qn: Optional[int] = None
-    ) -> AudioStreamingSourceMeta:
-        dash = pgc_play.result.dash
-        source_pool: List[GetPGCPlayResultDashMediaItem] = []
+    def _get_play_audio_pool(cls, *args: Any, **kwargs: Any) -> List[DashMediaItem]:  # NOQA
+        play_dm: GetPGCPlayResponse = kwargs['play_dm']
+        dash = play_dm.result.dash
+        source_pool: List[DashMediaItem] = []
         if dash.dolby.audio is not None and len(dash.dolby.audio) > 0:
             source_pool.extend(dash.dolby.audio)
         if dash.flac is not None and dash.flac.audio is not None:
             source_pool.append(dash.flac.audio)
         if dash.audio is not None:
             source_pool.extend(dash.audio)
-
-        avail_bitrates = list(set([item.id_field for item in source_pool]))
-        avail_bitrates.sort(reverse=is_hq_preferred)
-        if qn is not None:
-            avail_bitrates = [avail_bitrate for avail_bitrate in avail_bitrates if avail_bitrate <= qn]
-            if avail_bitrates:
-                avail_bitrates.sort(reverse=True)
-        qn, *_ = avail_bitrates
-        media, *_ = [item for item in source_pool if item.id_field == qn]
-        return AudioStreamingSourceMeta(
-            url=media.base_url,
-            qn=media.id_field,
-            mime_type=media.mime_type
-        )
+        return source_pool

--- a/bili_jean/streaming/streaming_service.py
+++ b/bili_jean/streaming/streaming_service.py
@@ -2,16 +2,22 @@
 Service component to process Bilibili streaming resource
 """
 import logging
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from urllib.parse import urlparse
 
 from .components import get_streaming_component_kls
 from ..constants import (
+    StreamingCategory,
     WEB_VIEW_URL_ID_TYPE_MAPPING,
     WEB_VIEW_URL_CATEGORY_MAPPING
 )
 from ..proxy_service import ProxyService
-from ..schemes import Page, StreamingWebViewMeta
+from ..schemes import (
+    AudioStreamingSourceMeta,
+    Page,
+    StreamingWebViewMeta,
+    VideoStreamingSourceMeta
+)
 
 
 logger = logging.getLogger(__name__)
@@ -77,5 +83,37 @@ class StreamingService:
             bvid=web_view_meta.bvid,
             season_id=web_view_meta.season_id,
             ep_id=web_view_meta.ep_id,
+            sess_data=sess_data
+        )
+
+    @classmethod
+    def get_page_streaming_src(
+        cls,
+        category: str,
+        cid: Optional[int] = None,
+        ep_id: Optional[int] = None,
+        bvid: Optional[str] = None,
+        aid: Optional[int] = None,
+        is_video_hq_preferred: bool = True,
+        video_qn: Optional[int] = None,
+        is_video_codec_eff_preferred: bool = True,
+        video_codec_number: Optional[int] = None,
+        is_audio_hq_preferred: bool = True,
+        audio_qn: Optional[int] = None,
+        sess_data: Optional[str] = None
+    ) -> Tuple[VideoStreamingSourceMeta, AudioStreamingSourceMeta]:
+        streaming_category = StreamingCategory.from_value(category)
+        component_kls = get_streaming_component_kls(streaming_category)
+        return component_kls.get_page_streaming_src(
+            cid=cid,
+            ep_id=ep_id,
+            bvid=bvid,
+            aid=aid,
+            is_video_hq_preferred=is_video_hq_preferred,
+            video_qn=video_qn,
+            is_video_codec_eff_preferred=is_video_codec_eff_preferred,
+            video_codec_number=video_codec_number,
+            is_audio_hq_preferred=is_audio_hq_preferred,
+            audio_qn=audio_qn,
             sess_data=sess_data
         )

--- a/tests/unittest/streaming/components/test_pgc.py
+++ b/tests/unittest/streaming/components/test_pgc.py
@@ -243,7 +243,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -281,7 +281,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -320,7 +320,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -359,7 +359,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -397,7 +397,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -435,7 +435,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -474,7 +474,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
             '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -485,7 +485,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
         )
         actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
             cid=239927346,
-            audio_qn=AudioBitRateID.BPS_64K.value
+            audio_qn=AudioBitRateID.BPS_64K.value.bit_rate_id
         )
         self.assertEqual(
             actual_video_src.url,
@@ -512,7 +512,7 @@ class PGCComponentGetPageStreamingSrcTestCase(TestCase):
             '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
             '&buvid=&build=0&f=p_0_0&agrr=1&bw=8406&logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_64K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_64K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     def test_get_page_streaming_src_without_identifier(self):

--- a/tests/unittest/streaming/components/test_pgc.py
+++ b/tests/unittest/streaming/components/test_pgc.py
@@ -8,11 +8,22 @@ from unittest.mock import patch
 
 from requests.exceptions import ReadTimeout, Timeout
 
-from bili_jean.constants import StreamingCategory
+from bili_jean.constants import (
+    AudioBitRateID,
+    QualityNumber,
+    StreamingCategory,
+    VideoCodecID
+)
 from bili_jean.streaming.components import PGCComponent
 from tests.utils import get_mocked_response
 
 
+with open('tests/mock_data/proxy/pgc_play/pgc_play_ep199612.json', 'r') as fp:
+    DATA_PLAY = json.load(fp)
+with open('tests/mock_data/proxy/pgc_play/pgc_play_ep1113563_unpurchased.json', 'r') as fp:
+    DATA_PLAY_UNPURCHASED = json.load(fp)
+with open('tests/mock_data/proxy/pgc_play/pgc_play_ep199612_trial.json', 'r') as fp:
+    DATA_PLAY_TRIAL = json.load(fp)
 with open('tests/mock_data/proxy/pgc_view/pgc_view_ep232465.json', 'r') as fp:
     DATA_VIEW = json.load(fp)
 with open('tests/mock_data/proxy/pgc_view/pgc_view_ep1.json', 'r') as fp:
@@ -27,7 +38,7 @@ with open('tests/mock_data/proxy/pgc_view/pgc_view_ep249469.json', 'r') as fp:
     DATA_VIEW_SECTION_WITH_UGC_EPISODE = json.load(fp)
 
 
-class PGCComponentTestCase(TestCase):
+class PGCComponentGetViewsTestCase(TestCase):
 
     @patch('bili_jean.proxy_service.ProxyService.get')
     def test_get_views_by_not_exist_ep_id(self, mocked_request):
@@ -194,3 +205,316 @@ class PGCComponentTestCase(TestCase):
     def test_get_views_without_params(self):
         with self.assertRaises(ValueError):
             PGCComponent.get_views()
+
+
+class PGCComponentGetPageStreamingSrcTestCase(TestCase):
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=34568185
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_sr1-1-100036.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=1a0aead873f447d4cb1f7b253bf6cf4d&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=663208&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.FOUR_K.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_prefer_lower_quality_video(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            ep_id=199612,
+            is_video_hq_preferred=False
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-100022.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=cosbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=36bbf9a398bbea7be24f18d8a09885a8&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=25541&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.AV1.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.P360.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_video_qn(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=239927346,
+            is_video_hq_preferred=False,
+            video_qn=QualityNumber.P480.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-100023.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=cosbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=31a82371ce83b835f98fd8091eb8d9a1&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=52833&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.AV1.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.P480.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_but_not_support_video_qn(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=239927346,
+            is_video_hq_preferred=False,
+            video_qn=QualityNumber.EIGHT_K.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_sr1-1-100036.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=1a0aead873f447d4cb1f7b253bf6cf4d&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=663208&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.FOUR_K.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_prefer_not_eff_codec(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=239927346,
+            is_video_codec_eff_preferred=False
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_sr1-1-100035.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=89468389f1a2973b67a8ae0d231bd519&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=1201845&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.AVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.FOUR_K.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_codec(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=239927346,
+            video_codec_number=VideoCodecID.HEVC.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_sr1-1-100036.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5'
+            '&nbs=1&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=1a0aead873f447d4cb1f7b253bf6cf4d&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=663208&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.FOUR_K.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_but_not_support_video_codec(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=239927346,
+            is_video_codec_eff_preferred=False,
+            video_codec_number=VideoCodecID.AV1.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_sr1-1-100036.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=1a0aead873f447d4cb1f7b253bf6cf4d&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=663208&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.FOUR_K.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=08'
+            '&upsig=e09589c2efdc79bc7d8af0c81c6bcee0&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_64Kbps_audio(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PGCComponent.get_page_streaming_src(
+            cid=239927346,
+            audio_qn=AudioBitRateID.BPS_64K.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_sr1-1-100036.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '&uipk=5&nbs=1&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721'
+            '&trid=37a603d7d7b849f9b79c977eed3fd45dp&mid=12363921&platform=pc&og=cos'
+            '&upsig=1a0aead873f447d4cb1f7b253bf6cf4d&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og'
+            '&bvc=vod&nettype=0&orderid=0,3&buvid=&build=0&f=p_0_0&agrr=1&bw=663208&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.FOUR_K.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-estghw.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30216.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721&trid=37a603d7d7b849f9b79c977eed3fd45dp'
+            '&mid=12363921&platform=pc&og=08&upsig=0635a254e683e981ad0e88b15f35179b'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=p_0_0&agrr=1&bw=8406&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_64K.value)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    def test_get_page_streaming_src_without_identifier(self):
+        with self.assertRaises(ValueError):
+            PGCComponent.get_page_streaming_src()

--- a/tests/unittest/streaming/components/test_pugv.py
+++ b/tests/unittest/streaming/components/test_pugv.py
@@ -111,8 +111,6 @@ class PUGVComponentTestCase(TestCase):
 
 class PUGVComponentGetPageStreamingSrcTestCase(TestCase):
 
-    maxDiff = None
-
     @patch('bili_jean.proxy_service.ProxyService.get')
     def test_get_page_streaming_src(self, mocked_request):
         mocked_request.return_value = get_mocked_response(

--- a/tests/unittest/streaming/components/test_pugv.py
+++ b/tests/unittest/streaming/components/test_pugv.py
@@ -8,11 +8,18 @@ from unittest.mock import patch
 
 from requests.exceptions import ReadTimeout, Timeout
 
-from bili_jean.constants import StreamingCategory
+from bili_jean.constants import (
+    AudioBitRateID,
+    QualityNumber,
+    StreamingCategory,
+    VideoCodecID
+)
 from bili_jean.streaming.components import PUGVComponent
 from tests.utils import get_mocked_response
 
 
+with open('tests/mock_data/proxy/pugv_play/pugv_play_ep482484.json', 'r') as fp:
+    DATA_PLAY = json.load(fp)
 with open('tests/mock_data/proxy/pugv_view/pugv_view_ss6838.json', 'r') as fp:
     DATA_VIEW = json.load(fp)
 with open('tests/mock_data/proxy/pugv_view/pugv_view_ss2.json', 'r') as fp:
@@ -100,3 +107,356 @@ class PUGVComponentTestCase(TestCase):
     def test_get_views_without_params(self):
         with self.assertRaises(ValueError):
             PUGVComponent.get_views()
+
+
+class PUGVComponentGetPageStreamingSrcTestCase(TestCase):
+
+    maxDiff = None
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100143.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=6a8bd0937951172427f01b38a41e5e40'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=177712&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_prefer_lower_quality_video(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            is_video_hq_preferred=False
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-estghw.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100109.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=upos&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=08&upsig=54e963f129c2b0c52cab01c76e2a46c0'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21045&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.P360.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_video_qn(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            is_video_hq_preferred=False,
+            video_qn=QualityNumber.P480.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100110.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=536105a034242d7a22f7edd874925596'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=30246&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.P480.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_but_not_support_video_qn(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            is_video_hq_preferred=False,
+            video_qn=QualityNumber.EIGHT_K.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100143.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=6a8bd0937951172427f01b38a41e5e40'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=177712&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_prefer_not_eff_codec(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            is_video_codec_eff_preferred=False
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30112.m4s'
+            '?e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=bdbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=08&upsig=510f90cdbf378dc7cff2a1f39043048f'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=391935&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.AVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_codec(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            video_codec_number=VideoCodecID.AVC.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30112.m4s'
+            '?e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=bdbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=08&upsig=510f90cdbf378dc7cff2a1f39043048f'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=391935&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.AVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_declared_but_not_support_video_codec(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            is_video_codec_eff_preferred=False,
+            video_codec_number=VideoCodecID.AV1.value
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100143.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=6a8bd0937951172427f01b38a41e5e40'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=177712&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_64Kbps_audio(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            audio_qn=AudioBitRateID.BPS_64K.value.bit_rate_id
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100143.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=6a8bd0937951172427f01b38a41e5e40'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=177712&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30216.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=fc93b9d7bd8e5b986f7f8ede04f707cd'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=5741&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_64K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_page_streaming_src_with_not_supported_audio(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PLAY).encode('utf-8')
+        )
+        actual_video_src, actual_audio_src = PUGVComponent.get_page_streaming_src(
+            ep_id=482484,
+            audio_qn=AudioBitRateID.BPS_DOLBY.value.bit_rate_id
+        )
+        self.assertEqual(
+            actual_video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100143.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=6a8bd0937951172427f01b38a41e5e40'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=177712&logo=80000000'
+        )
+        self.assertEqual(actual_video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(actual_video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(actual_video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            actual_audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5'
+            '&nbs=1&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3&buvid='
+            '&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
+
+    def test_get_page_streaming_src_without_identifier(self):
+        with self.assertRaises(ValueError):
+            PUGVComponent.get_page_streaming_src()

--- a/tests/unittest/streaming/components/test_ugc.py
+++ b/tests/unittest/streaming/components/test_ugc.py
@@ -287,7 +287,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -330,7 +330,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -374,7 +374,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -418,7 +418,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -461,7 +461,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -504,7 +504,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -547,7 +547,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')

--- a/tests/unittest/streaming/components/test_ugc.py
+++ b/tests/unittest/streaming/components/test_ugc.py
@@ -287,7 +287,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -330,7 +330,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -374,7 +374,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -418,7 +418,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -461,7 +461,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -504,7 +504,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -547,7 +547,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=0\\u0026bw=40047\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -559,7 +559,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
         actual_video_src, actual_audio_src = UGCComponent.get_page_streaming_src(
             cid=733892245,
             bvid='BV13L4y1K7th',
-            audio_qn=AudioBitRateID.BPS_DOLBY.value
+            audio_qn=AudioBitRateID.BPS_DOLBY.value.bit_rate_id
         )
         self.assertEqual(
             actual_video_src.url,
@@ -590,7 +590,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026nettype=0\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0'
             '\\u0026agrr=1\\u0026bw=56526\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_DOLBY.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_DOLBY.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')
@@ -602,7 +602,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
         actual_video_src, actual_audio_src = UGCComponent.get_page_streaming_src(
             cid=25954616353,
             bvid='BV13ht2ejE1S',
-            audio_qn=AudioBitRateID.BPS_HIRES.value
+            audio_qn=AudioBitRateID.BPS_HIRES.value.bit_rate_id
         )
         self.assertEqual(
             actual_video_src.url,
@@ -633,7 +633,7 @@ class UGCComponentGetPageStreamingSrcTestCase(TestCase):
             '\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0\\u0026agrr=1'
             '\\u0026bw=199130\\u0026logo=80000000'
         )
-        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_HIRES.value)
+        self.assertEqual(actual_audio_src.qn, AudioBitRateID.BPS_HIRES.value.bit_rate_id)
         self.assertEqual(actual_audio_src.mime_type, 'audio/mp4')
 
     @patch('bili_jean.proxy_service.ProxyService.get')

--- a/tests/unittest/streaming/test_streaming_service.py
+++ b/tests/unittest/streaming/test_streaming_service.py
@@ -6,10 +6,15 @@ import json
 from unittest import TestCase
 from unittest.mock import patch
 
-from requests.exceptions import InvalidSchema, MissingSchema
+from requests.exceptions import InvalidSchema, MissingSchema, ReadTimeout
 from requests.structures import CaseInsensitiveDict
 
-from bili_jean.constants import StreamingCategory
+from bili_jean.constants import (
+    AudioBitRateID,
+    QualityNumber,
+    StreamingCategory,
+    VideoCodecID
+)
 from bili_jean.schemes import Page
 from bili_jean.streaming.streaming_service import StreamingService
 from tests.utils import get_mocked_response
@@ -18,6 +23,14 @@ from tests.utils import get_mocked_response
 DATA_HTML = '<!DOCTYPE html><html lang="zh-Hans"></html>'
 
 
+with open('tests/mock_data/proxy/pgc_play/pgc_play_ep199612.json', 'r') as fp:
+    DATA_PGC_PLAY = json.load(fp)
+with open('tests/mock_data/proxy/pugv_play/pugv_play_ep482484.json', 'r') as fp:
+    DATA_PUGV_PLAY = json.load(fp)
+with open('tests/mock_data/proxy/pugv_play/pugv_play_ep482535_unpurchased.json', 'r') as fp:
+    DATA_PUGV_PLAY_UNPURCHASED = json.load(fp)
+with open('tests/mock_data/proxy/ugc_play/ugc_play_BV1X54y1C74U.json', 'r') as fp:
+    DATA_UGC_PLAY = json.load(fp)
 with open('tests/mock_data/proxy/pgc_view/pgc_view_ss12548.json', 'r') as fp:
     DATA_PGC_VIEW = json.load(fp)
 with open('tests/mock_data/proxy/pugv_view/pugv_view_ep482484.json', 'r') as fp:
@@ -324,3 +337,172 @@ class StreamingServiceGetViewsTestCase(TestCase):
 
         with self.assertRaises(ValueError):
             StreamingService.get_views(sample_url)
+
+
+class StreamingServiceGetPageStreamingSrcTestCase(TestCase):
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_ugc_page_streaming_src(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_UGC_PLAY).encode('utf-8')
+        )
+        video_src, audio_src = StreamingService.get_page_streaming_src(
+            category='ugc',
+            cid=239927346,
+            bvid='BV1X54y1C74U',
+            video_qn=QualityNumber.P480.value,
+            video_codec_number=VideoCodecID.HEVC.value,
+            audio_qn=AudioBitRateID.BPS_132K.value.bit_rate_id
+        )
+
+        self.assertEqual(
+            video_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/46/73/239927346/239927346_x2-1-30033.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M='
+            '\\u0026uipk=5\\u0026nbs=1\\u0026deadline=1728826357\\u0026gen=playurlv2\\u0026os=cosbv'
+            '\\u0026oi=1929021803\\u0026trid=4cc3bb76000944a8b32cd0333abcfad8u\\u0026mid=0\\u0026platform=pc'
+            '\\u0026og=cos\\u0026upsig=9db3cff93d80797550f851d7ae044318'
+            '\\u0026uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og\\u0026bvc=vod\\u0026nettype=0'
+            '\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0\\u0026agrr=0'
+            '\\u0026bw=39113\\u0026logo=80000000'
+        )
+        self.assertEqual(video_src.qn, QualityNumber.P480.value)
+        self.assertEqual(video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            audio_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/46/73/239927346/239927346-1-30232.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=\\u0026uipk=5'
+            '\\u0026nbs=1\\u0026deadline=1728826357\\u0026gen=playurlv2\\u0026os=upos\\u0026oi=1929021803'
+            '\\u0026trid=4cc3bb76000944a8b32cd0333abcfad8u\\u0026mid=0\\u0026platform=pc\\u0026og=hw'
+            '\\u0026upsig=f9d4e954eca822bda3deeb6d55e03264'
+            '\\u0026uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og\\u0026bvc=vod\\u0026nettype=0'
+            '\\u0026orderid=0,3\\u0026buvid=\\u0026build=0\\u0026f=u_0_0\\u0026agrr=0'
+            '\\u0026bw=16667\\u0026logo=80000000'
+        )
+        self.assertEqual(audio_src.qn, AudioBitRateID.BPS_132K.value.bit_rate_id)
+        self.assertEqual(audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_ugc_page_streaming_src_with_http_error(self, mocked_request):
+        mocked_request.side_effect = ReadTimeout(
+            'HTTPSConnectionPool(host=\'api.bilibili.com\', port=443): Read timed out. (read timeout=5)'
+        )
+        with self.assertRaises(ReadTimeout):
+            StreamingService.get_page_streaming_src(
+                category='ugc',
+                cid=239927346,
+                bvid='BV1X54y1C74U',
+                video_qn=QualityNumber.P480.value,
+                video_codec_number=VideoCodecID.HEVC.value,
+                audio_qn=AudioBitRateID.BPS_132K.value.bit_rate_id
+            )
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_pgc_page_streaming_src(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PGC_PLAY).encode('utf-8')
+        )
+        video_src, audio_src = StreamingService.get_page_streaming_src(
+            category='pgc',
+            cid=34568185,
+            bvid='BV14W411g72e',
+            video_qn=QualityNumber.PPLUS_1080.value,
+            video_codec_number=VideoCodecID.AVC.value,
+            audio_qn=AudioBitRateID.BPS_192K.value.bit_rate_id
+        )
+
+        self.assertEqual(
+            video_src.url,
+            'https://upos-sz-estgoss.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30112.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730801113&gen=playurlv2&os=upos&oi=2071715721&trid=37a603d7d7b849f9b79c977eed3fd45dp'
+            '&mid=12363921&platform=pc&og=08&upsig=0a284a9dde2d91619c3d873a60d5f86b'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=p_0_0&agrr=1&bw=477918&logo=80000000'
+        )
+        self.assertEqual(video_src.qn, QualityNumber.PPLUS_1080.value)
+        self.assertEqual(video_src.codec_id, VideoCodecID.AVC.value)
+        self.assertEqual(video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            audio_src.url,
+            'https://upos-sz-mirrorbd.bilivideo.com/upgcxcode/85/81/34568185/34568185_p1-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730801113&gen=playurlv2&os=bdbv&oi=2071715721&trid=37a603d7d7b849f9b79c977eed3fd45dp'
+            '&mid=12363921&platform=pc&og=08&upsig=e09589c2efdc79bc7d8af0c81c6bcee0'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=p_0_0&agrr=1&bw=39881&logo=80000000'
+        )
+        self.assertEqual(audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_pugv_page_streaming_src(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PUGV_PLAY).encode('utf-8')
+        )
+        video_src, audio_src = StreamingService.get_page_streaming_src(
+            category='pugv',
+            ep_id=482484,
+            video_qn=QualityNumber.P1080.value,
+            video_codec_number=VideoCodecID.HEVC.value,
+            audio_qn=AudioBitRateID.BPS_192K.value.bit_rate_id
+        )
+
+        self.assertEqual(
+            video_src.url,
+            'https://upos-sz-estghw.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-100113.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=upos&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=08&upsig=84dafcc06ce9f3b12d76e8d0d6633d33'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=85423&logo=80000000'
+        )
+        self.assertEqual(video_src.qn, QualityNumber.P1080.value)
+        self.assertEqual(video_src.codec_id, VideoCodecID.HEVC.value)
+        self.assertEqual(video_src.mime_type, 'video/mp4')
+        self.assertEqual(
+            audio_src.url,
+            'https://upos-sz-mirrorcos.bilivideo.com/upgcxcode/25/99/1444089925/1444089925-1-30280.m4s?'
+            'e=ig8euxZM2rNcNbdlhoNvNC8BqJIzNbfqXBvEqxTEto8BTrNvN0GvT90W5JZMkX_'
+            'YN0MvXg8gNEV4NC8xNEV4N03eN0B5tZlqNxTEto8BTrNvNeZVuJ10Kj_'
+            'g2UB02J0mN0B5tZlqNCNEto8BTrNvNC7MTX502C8f2jmMQJ6mqF2fka1mqx6gqj0eN0B599M=&uipk=5&nbs=1'
+            '&deadline=1730824061&gen=playurlv2&os=cosbv&oi=2071715721&trid=84ab82a4174540899e7f9fae8bb349dcu'
+            '&mid=0&platform=pc&og=cos&upsig=dd554ca81997015e71ab3db1f6779711'
+            '&uparams=e,uipk,nbs,deadline,gen,os,oi,trid,mid,platform,og&bvc=vod&nettype=0&orderid=0,3'
+            '&buvid=&build=0&f=u_0_0&agrr=0&bw=21748&logo=80000000'
+        )
+        self.assertEqual(audio_src.qn, AudioBitRateID.BPS_192K.value.bit_rate_id)
+        self.assertEqual(audio_src.mime_type, 'audio/mp4')
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    def test_get_pugv_page_streaming_src_unpurchased(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            json.dumps(DATA_PUGV_PLAY_UNPURCHASED).encode('utf-8')
+        )
+        with self.assertRaises(ValueError) as context:
+            StreamingService.get_page_streaming_src(
+                category='pugv',
+                ep_id=482535,
+                video_qn=QualityNumber.P1080.value,
+                video_codec_number=VideoCodecID.HEVC.value,
+                audio_qn=AudioBitRateID.BPS_192K.value.bit_rate_id
+            )
+        self.assertEqual(
+            str(context.exception),
+            'request play data error: 访问权限不足'
+        )

--- a/tests/unittest/test_constants.py
+++ b/tests/unittest/test_constants.py
@@ -73,7 +73,7 @@ class AudioBitRateIDTestCase(TestCase):
     def test_from_value(self):
         self.assertEqual(
             AudioBitRateID.from_value(30280),
-            AudioBitRateID.BPS_192
+            AudioBitRateID.BPS_192K
         )
 
     def test_from_value_with_unsupported_number(self):

--- a/tests/unittest/test_constants.py
+++ b/tests/unittest/test_constants.py
@@ -7,6 +7,7 @@ from bili_jean.constants import (
     AudioBitRateID,
     FormatNumberValue,
     QualityNumber,
+    StreamingCategory,
     VideoCodecID
 )
 
@@ -92,3 +93,16 @@ class VideoCodecIDTestCase(TestCase):
     def test_from_value_with_unsupported_number(self):
         with self.assertRaises(ValueError):
             VideoCodecID.from_value(0)
+
+
+class StreamingCategoryTestCase(TestCase):
+
+    def test_from_value(self):
+        self.assertEqual(
+            StreamingCategory.from_value('ugc'),
+            StreamingCategory.UGC
+        )
+
+    def test_from_value_with_invalid_value(self):
+        with self.assertRaises(ValueError):
+            StreamingCategory.from_value('not_exist_category')

--- a/tests/unittest/test_constants.py
+++ b/tests/unittest/test_constants.py
@@ -4,8 +4,10 @@ Unit test for constants
 from unittest import TestCase
 
 from bili_jean.constants import (
+    AudioBitRateID,
     FormatNumberValue,
-    QualityNumber
+    QualityNumber,
+    VideoCodecID
 )
 
 
@@ -64,3 +66,29 @@ class FormatNumberValueTestCase(TestCase):
             ),
             1168,  # 010010010000
         )
+
+
+class AudioBitRateIDTestCase(TestCase):
+
+    def test_from_value(self):
+        self.assertEqual(
+            AudioBitRateID.from_value(30280),
+            AudioBitRateID.BPS_192
+        )
+
+    def test_from_value_with_unsupported_number(self):
+        with self.assertRaises(ValueError):
+            AudioBitRateID.from_value(0)
+
+
+class VideoCodecIDTestCase(TestCase):
+
+    def test_from_value(self):
+        self.assertEqual(
+            VideoCodecID.from_value(13),
+            VideoCodecID.AV1
+        )
+
+    def test_from_value_with_unsupported_number(self):
+        with self.assertRaises(ValueError):
+            VideoCodecID.from_value(0)

--- a/tests/unittest/test_page_download_service.py
+++ b/tests/unittest/test_page_download_service.py
@@ -1,0 +1,162 @@
+"""
+Unit test for PageDownloadService
+"""
+import copy
+from http import HTTPStatus
+import json
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from requests.structures import CaseInsensitiveDict
+
+from bili_jean.constants import HEADERS
+from bili_jean.page_download_service import DownloadError, PageDownloadService
+from tests.utils import get_mocked_response
+
+
+class PageDownloadServiceTestCase(TestCase):
+
+    @patch('bili_jean.proxy_service.ProxyService.head')
+    def test_remote_file_size(self, mocked_request):
+        mocked_request.return_value = get_mocked_response(
+            HTTPStatus.OK.value,
+            ''.encode('utf-8'),
+            CaseInsensitiveDict({
+                'Date': 'Tue, 26 Nov 2024 13:17:22 GMT',
+                'Content-Type': 'application/octet-stream',
+                'Content-Length': '41231718',
+                'Connection': 'keep-alive',
+                'X-Upsig-Version': '20231123',
+                'Access-Control-Allow-Origin': 'https://www.bilibili.com',
+                'Access-Control-Max-Age': '0',
+                'Accept-Ranges': 'bytes',
+                'ETag': '"DA04738AEA59B29C92547378E6ED54CF"',
+                'Last-Modified': 'Sat, 26 Oct 2024 11:34:43 GMT',
+                'Content-MD5': '2gRziupZspySVHN45u1Uzw==',
+                'X-Request-ID': '6745CA62471A7C313517E622',
+                'Access-Control-Expose-Headers': 'Content-Length, Content-Range'
+            })
+        )
+        mock_source_url = 'https://upos-sz-estgoss.bilivideo.com/upgcxcode/46/73/239927346/239927346-1-100027.m4s'
+
+        download_service = PageDownloadService(
+            url=mock_source_url,
+            file='/Users/usharerose/Movies/bilibili/ugc/239927346/sample.mp4'
+        )
+        actual_remote_file_size = download_service.remote_file_size
+        self.assertEqual(actual_remote_file_size, 41231718)
+
+    @patch('builtins.open', new_callable=MagicMock)
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    @patch('bili_jean.proxy_service.ProxyService.head')
+    def test_download(self, mocked_head_request, mocked_get_request, mocked_open):
+        mocked_head_request.return_value = MagicMock()
+        mocked_head_request.return_value.status_code = HTTPStatus.OK.value
+        mocked_head_request.return_value.headers = CaseInsensitiveDict({
+            'Content-Length': '1024'
+        })
+
+        mocked_get_request.return_value = MagicMock()
+        mocked_get_request.return_value.status_code = HTTPStatus.PARTIAL_CONTENT.value
+        mocked_get_request.return_value.iter_content = MagicMock(return_value=[b'chunk_0', b'chunk_1'])
+
+        mocked_source_url = 'https://example.com/file.m4s'
+        mocked_file_path = '/tmp/test_file.mp4'
+        download_service = PageDownloadService(
+            url=mocked_source_url,
+            file=mocked_file_path
+        )
+
+        mocked_path = MagicMock(spec=Path)
+        mocked_path.parent.mkdir.return_value = None
+        mocked_tmp_path = MagicMock(spec=Path)
+        mocked_tmp_path.exists.return_value = False  # simulate no temp file exists
+        mocked_tmp_path.rename.return_value = None
+
+        download_service._path = mocked_path  # Override with mock
+        download_service._tmp_path = mocked_tmp_path
+
+        mock_local_file = MagicMock()  # Simulate the file object returned by open
+        mocked_open.return_value.__enter__.return_value = mock_local_file
+
+        # Start downloading
+        download_service.download()
+
+        # Verify that the file's parent directory is created
+        mocked_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+        headers = copy.deepcopy(HEADERS)
+        headers.update({'Range': 'bytes=0-'})
+        # Verify that get was called with the correct Range header
+        mocked_get_request.assert_called_once_with(
+            url=mocked_source_url,
+            headers=headers,
+            stream=True
+        )
+
+        # Verify that the temporary file is renamed to the final file
+        mocked_tmp_path.rename.assert_called_once_with(mocked_path)
+
+    @patch('bili_jean.proxy_service.ProxyService.get')
+    @patch('bili_jean.proxy_service.ProxyService.head')
+    def test_download_with_source_403(self, mocked_head_request, mocked_get_request):
+        mocked_head_request.return_value = MagicMock()
+        mocked_head_request.return_value.status_code = HTTPStatus.OK.value
+        mocked_head_request.return_value.headers = CaseInsensitiveDict({
+            'Content-Length': '1024'
+        })
+
+        mocked_get_request.return_value = MagicMock()
+        mocked_get_request.return_value.status_code = HTTPStatus.FORBIDDEN.value
+
+        mocked_source_url = 'https://example.com/file.m4s'
+        mocked_file_path = '/tmp/test_file.mp4'
+        download_service = PageDownloadService(
+            url=mocked_source_url,
+            file=mocked_file_path
+        )
+
+        mocked_path = MagicMock(spec=Path)
+        mocked_path.parent.mkdir.return_value = None
+        mocked_tmp_path = MagicMock(spec=Path)
+        mocked_tmp_path.exists.return_value = False  # simulate no temp file exists
+        mocked_tmp_path.rename.return_value = None
+
+        download_service._path = mocked_path  # Override with mock
+        download_service._tmp_path = mocked_tmp_path
+
+        with self.assertRaises(DownloadError):
+            download_service.download()
+
+    @patch('bili_jean.proxy_service.ProxyService.head')
+    def test_download_with_remote_file_size_403(self, mocked_head_request):
+        mocked_head_request.return_value = MagicMock()
+        mocked_head_request.return_value.status_code = HTTPStatus.FORBIDDEN.value
+
+        mocked_source_url = 'https://example.com/file.m4s'
+        mocked_file_path = '/tmp/test_file.mp4'
+        download_service = PageDownloadService(
+            url=mocked_source_url,
+            file=mocked_file_path
+        )
+
+        mocked_path = MagicMock(spec=Path)
+        mocked_path.parent.mkdir.return_value = None
+        mocked_tmp_path = MagicMock(spec=Path)
+        mocked_tmp_path.exists.return_value = False
+
+        download_service._path = mocked_path  # Override with mock
+        download_service._tmp_path = mocked_tmp_path
+
+        with self.assertRaises(DownloadError):
+            download_service.download()
+
+    def test_init_with_directory_path(self):
+        mocked_source_url = 'https://example.com/file.m4s'
+        mocked_file_path = './'
+        with self.assertRaises(ValueError):
+            PageDownloadService(
+                url=mocked_source_url,
+                file=mocked_file_path
+            )


### PR DESCRIPTION
## Changes Summary
get streaming resources URL and download it from remote to local

## Changes Items
1. implement `get_page_streaming_src`, get video and audio resources by parameters. support `UGC`, `PGC` and `PUGV`.
2. implement a service, which process downloading from declared resource URL to local
